### PR TITLE
Retry screen rotation patch update

### DIFF
--- a/recipes-nemomobile/lipstick/lipstick/0001-Rotate-screen-for-harmony.patch
+++ b/recipes-nemomobile/lipstick/lipstick/0001-Rotate-screen-for-harmony.patch
@@ -8,13 +8,13 @@ Subject: [PATCH] Rotate screen for harmony
  1 file changed, 2 insertions(+)
 
 diff --git a/src/compositor/lipstickcompositor.cpp b/src/compositor/lipstickcompositor.cpp
-index 5653eaa..5b40362 100644
+index 4dce9d7b..cf5a796e 100644
 --- a/src/compositor/lipstickcompositor.cpp
 +++ b/src/compositor/lipstickcompositor.cpp
-@@ -403,6 +403,8 @@ void LipstickCompositor::initialize()
-     if (!systemBus.registerObject("/", this)) {
-         qWarning("Unable to register object at path /: %s", systemBus.lastError().message().toUtf8().constData());
-     }
+@@ -397,6 +397,8 @@ void LipstickCompositor::initialize()
+     QDBusMessage message = QDBusMessage::createMethodCall(MCE_SERVICE, MCE_REQUEST_PATH, MCE_REQUEST_IF, MCE_DISPLAY_LPM_SET_SUPPORTED);
+     message.setArguments(QVariantList() << ambientSupported());
+     QDBusConnection::systemBus().asyncCall(message);
 +
 +    setScreenOrientation(Qt::InvertedLandscapeOrientation);
  }

--- a/recipes-nemomobile/lipstick/lipstick/0001-Rotate-screen-for-harmony.patch
+++ b/recipes-nemomobile/lipstick/lipstick/0001-Rotate-screen-for-harmony.patch
@@ -1,4 +1,4 @@
-From 6470c907014f3f892b8f443fdeceec7663afb0c7 Mon Sep 17 00:00:00 2001
+From a8c863afa7b5f22edc2b551b5ef01a63402f81e5 Mon Sep 17 00:00:00 2001
 From: Florent Revest <revestflo@gmail.com>
 Date: Sat, 8 Jul 2017 14:12:06 +0100
 Subject: [PATCH] Rotate screen for harmony
@@ -8,15 +8,18 @@ Subject: [PATCH] Rotate screen for harmony
  1 file changed, 2 insertions(+)
 
 diff --git a/src/compositor/lipstickcompositor.cpp b/src/compositor/lipstickcompositor.cpp
-index 4dce9d7b..174c5519 100644
+index 5653eaa..5b40362 100644
 --- a/src/compositor/lipstickcompositor.cpp
 +++ b/src/compositor/lipstickcompositor.cpp
-@@ -376,6 +376,8 @@ void LipstickCompositor::onSurfaceDying()
-         item->m_windowClosed = true;
-         item->tryRemove();
+@@ -403,6 +403,8 @@ void LipstickCompositor::initialize()
+     if (!systemBus.registerObject("/", this)) {
+         qWarning("Unable to register object at path /: %s", systemBus.lastError().message().toUtf8().constData());
      }
 +
 +    setScreenOrientation(Qt::InvertedLandscapeOrientation);
  }
  
- void LipstickCompositor::initialize()
+ void LipstickCompositor::windowDestroyed(LipstickCompositorWindow *item)
+-- 
+2.7.4
+


### PR DESCRIPTION
This is a second attempt at updating the Harmony screen rotation patch.
(The first was in 3f6922f.)

It looks like `devtool` mangled that one a bit, leading to the rotation
line being added to the onSurfaceDying() function rather than the
initialize() function, so it wouldn't take effect (at least until the
first surface died?)

Fixes #17.

Currently a draft while I finish building and testing that the fix
actually does what it's supposed to.